### PR TITLE
Log complete URL when tracking page views

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ Vue.extend({
 
 - **id** - The instrumentation key of your AppInsights resource on Azure.
 - **router** - The router instance, which events should be tracked as page views _(optional)_.
-- **basePath** - Prefix of the tracked page view _(optional, default is '(Application Root)')_
-- **appInsights** - Can be used if you don't want this module to initialize the AppInsights instance _(optional)_.
+**baseName** String that will prefix the name of the tracked page _(optional, default is '(Vue App)')_
+**appInsights** Instance of the Application Insights client  _(optional)_.
 - **trackInitialPageView** - Boolean that determines whether or not the initial page view should be tracked. _(optional, defaults to true)_
 
 ## Initializing AppInsights from outside the Vue application

--- a/dist/vue-application-insights.js
+++ b/dist/vue-application-insights.js
@@ -52,21 +52,18 @@ function setupPageTracking(options, Vue) {
 
   var router = options.router;
 
-  var basePath = options.basePath || '(Application Root)';
-
-  var pathFormatter = function pathFormatter(path) {
-    return basePath + '/' + path.substr(1);
-  };
+  var baseName = options.baseName || '(Vue App)';
 
   router.beforeEach(function (route, from, next) {
-    var path = pathFormatter(route.fullPath);
-    Vue.appInsights.startTrackPage(path);
+    var name = baseName + ' / ' + route.name;
+    Vue.appInsights.startTrackPage(name);
     next();
   });
 
   router.afterEach(function (route) {
-    var path = pathFormatter(route.fullPath);
-    Vue.appInsights.stopTrackPage(path, route.fullPath);
+    var name = baseName + ' / ' + route.name;
+    var url = location.protocol + '//' + location.host + '/' + route.fullPath;
+    Vue.appInsights.stopTrackPage(name, url);
   });
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -45,20 +45,18 @@ function setupPageTracking(options, Vue) {
 
   const router = options.router
 
-  const basePath = options.basePath || '(Application Root)'
-
-  const pathFormatter = path =>
-  basePath + '/' + path.substr(1)
+  const baseName = options.baseName || '(Vue App)'
 
   router.beforeEach( (route, from, next) => {
-    const path = pathFormatter(route.fullPath);
-    Vue.appInsights.startTrackPage(path)
+    const name = baseName + ' / ' + route.name;
+    Vue.appInsights.startTrackPage(name)
     next()
   })
 
   router.afterEach( route => {
-    const path = pathFormatter(route.fullPath);
-    Vue.appInsights.stopTrackPage(path, route.fullPath)
+    const name = baseName + ' / ' + route.name;
+    const url = location.protocol + '//' + location.host + '/' + route.fullPath;
+    Vue.appInsights.stopTrackPage(name, url);
   })
 }
 


### PR DESCRIPTION
Feel free to merge this pull request if it is to your liking. It will change the module in the following way:

- The config variable basePath is renamed to baseName. Since the variable is used to prefix the name of the pageView this name made more sense.
- It will register the name of the route instead of the path as `name` in app insight. Duplicating the path of the route doesn't make much sense
- It ensures that the entire url of the route is logged, not only the relative path of the route.

Cheers!