### PR TITLE
use operation id per page

### DIFF
--- a/dist/vue-application-insights.js
+++ b/dist/vue-application-insights.js
@@ -60,6 +60,8 @@ function setupPageTracking(options, Vue) {
 
   router.beforeEach(function (route, from, next) {
     var name = baseName + ' / ' + route.name;
+    Vue.appInsights.context.telemetryTrace.traceID = _applicationinsightsWeb.Util.generateW3CId();
+    Vue.appInsights.context.telemetryTrace.name = route.name;
     Vue.appInsights.startTrackPage(name);
     next();
   });

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 
-import { ApplicationInsights } from '@microsoft/applicationinsights-web'
+import { ApplicationInsights, Util } from '@microsoft/applicationinsights-web'
 
 /**
  * Install function passed to Vue.use() show documentation on vue.js website.
@@ -53,6 +53,8 @@ function setupPageTracking(options, Vue) {
 
   router.beforeEach( (route, from, next) => {
     const name = baseName + ' / ' + route.name;
+    Vue.appInsights.context.telemetryTrace.traceID = Util.generateW3CId();
+    Vue.appInsights.context.telemetryTrace.name = route.name;
     Vue.appInsights.startTrackPage(name)
     next()
   })


### PR DESCRIPTION
Currently application insights logs one session as one operation and every page with the operation name "/". This makes the Performance view in the application insights less helpful.
With this change it will look like:
![grafik](https://user-images.githubusercontent.com/4662023/105325276-b3a01180-5bcc-11eb-8006-a4310343b4dc.png)

This sets the same property as the official angular plugin: https://github.com/microsoft/ApplicationInsights-JS/blob/ae71ebf806da82e149b0af60f00d70b2c1d3e3f0/extensions/applicationinsights-angularplugin-js/src/AngularPlugin.ts#L83-L84

I am unsure if this is an breaking change. I see three options:
- Since it can be viewed as a bug fix, simple change this
- Hide this behind an option, that is off by default
- Release this with an new major version