### PR TITLE
Add basic support for Vue 3

### DIFF
--- a/dist/vue-application-insights.js
+++ b/dist/vue-application-insights.js
@@ -6,6 +6,10 @@ Object.defineProperty(exports, "__esModule", {
 
 var _applicationinsightsWeb = require('@microsoft/applicationinsights-web');
 
+function isRunningVue3(vue) {
+  return vue.version.startsWith('3.');
+}
+
 /**
  * Install function passed to Vue.use() show documentation on vue.js website.
  *
@@ -41,11 +45,15 @@ function install(Vue, options) {
     }
   }
 
-  Object.defineProperty(Vue.prototype, '$appInsights', {
-    get: function get() {
-      return Vue.appInsights;
-    }
-  });
+  if (isRunningVue3(Vue)) {
+    Vue.provide('appInsights', Vue.appInsights);
+  } else {
+    Object.defineProperty(Vue.prototype, '$appInsights', {
+      get: function get() {
+        return Vue.appInsights;
+      }
+    });
+  }
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,10 @@
 
 import { ApplicationInsights, Util } from '@microsoft/applicationinsights-web'
 
+function isRunningVue3(vue) {
+  return vue.version.startsWith('3.');
+}
+
 /**
  * Install function passed to Vue.use() show documentation on vue.js website.
  *
@@ -32,13 +36,15 @@ function install (Vue, options) {
     } else {
       router.onReady(() => setupPageTracking(options, Vue))
     }
-
   }
 
-  Object.defineProperty(Vue.prototype, '$appInsights', {
-    get: () => Vue.appInsights
-  })
-
+  if (isRunningVue3(Vue)) {
+    Vue.provide('appInsights', Vue.appInsights);
+  } else {
+    Object.defineProperty(Vue.prototype, '$appInsights', {
+      get: () => Vue.appInsights
+    })
+  }
 }
 
 /**


### PR DESCRIPTION
Because Vue 3 now sends in an object and not a function when setting up a plugin, there is an error thrown from using the .prototype call in the install function. This PR identifies if Vue 3 is being used, and if that is the case it uses Vue.provide('appInsights'... to make appInsights available to other parts of the application.